### PR TITLE
Added possibility to use active monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Role Variables
 # defaults file for ansible-snmpd
 snmpd_config: true
 snmpd_enable: true
+snmpd_trap: false
 
 # Define read-only snmpd settings
 snmpd_authorized_networks: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 # defaults file for ansible-snmpd
 snmpd_config: true
 snmpd_enable: true
+snmpd_trap: false
 
 # Define read-only snmpd settings
 snmpd_authorized_networks: []

--- a/templates/snmpd.conf.j2
+++ b/templates/snmpd.conf.j2
@@ -4,6 +4,9 @@ view   systemonly  included   .1.3.6.1.2.1.25.1
 {% if snmpd_authorized_networks is defined and snmpd_enable %}
 {%   for item in snmpd_authorized_networks %}
 rocommunity {{ item.community }} {{ item.network }}
+{%     if snmpd_trap %}
+trapcommunity {{ item.community }} {{ item.network }}
+{%     endif %}
 {%   endfor %}
 {% endif %}
 rocommunity public  default    -V systemonly


### PR DESCRIPTION
Added variable snmpd_trap, which is false by default. When enabled will add
trapcommunity for each authorized_networks with the same community value